### PR TITLE
Add dockerfile and docker section install section to readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Base image
+FROM osrf/ros:kinetic-desktop-full
+
+MAINTAINER Finn Rietz <5rietz@informatik.uni-hamburg.de>
+
+# (RUN is executed when image is build)
+RUN apt-get update
+RUN apt-get install -y vim wget libprotobuf-dev protobuf-compiler
+
+# packages required for Pepper Gazebo simulation
+RUN apt-get install -y ros-kinetic-tf2-sensor-msgs ros-kinetic-ros-control ros-kinetic-ros-controllers ros-kinetic-gazebo-ros ros-kinetic-gazebo-ros-control ros-kinetic-gazebo-plugins ros-kinetic-controller-manager ros-kinetic-ddynamic-reconfigure-python
+
+# install pepper meshes. We have to pipe this into 'yes' to agree to the license. otherwise docker build get's stuck on this step...
+# we also have these debian environment params, otherwise the yes still gets stuck on the prompt in the mesh installation
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND teletype
+RUN yes | apt-get install ros-kinetic-pepper-meshes
+
+# Clone the required repos into a catkin workspace, which we than compile
+RUN git clone -b correct_chain_model_and_gazebo_enabled https://github.com/awesomebytes/pepper_robot /catkin_ws/src/pepper_robot
+RUN git clone -b simulation_that_works https://github.com/awesomebytes/pepper_virtual /catkin_ws/src/pepper_virtual
+RUN git clone https://github.com/awesomebytes/gazebo_model_velocity_plugin /catkin_ws/src/gazebo_model_velocity_plugin
+
+# build the catkin_ws inside the container
+RUN /bin/bash -c '. /opt/ros/kinetic/setup.bash && cd /catkin_ws && catkin_make'
+
+# we add these two commands to the bashrc in the container, so that the entrypoint and workspacea will be sourced,
+# whenever a new bash session is instantiated in the container
+RUN echo 'source /ros_entrypoint.sh' >>  /root/.bashrc
+RUN echo 'source /catkin_ws/devel/setup.bash' >> /root/.bashrc

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ And further variants that don't have the arms of the robot which reduce CPU load
 - `roslaunch pepper_gazebo_plugin pepper_gazebo_plugin_in_office_CPU_no_arms.launch`
 
 
+# Installation
 This should get your workspace up and running:
 ```bash
 mkdir -p pepper_sim_ws/src
@@ -44,6 +45,28 @@ roslaunch pepper_gazebo_plugin pepper_gazebo_plugin_in_office_CPU.launch
 rosrun rviz rviz -d `rospack find pepper_gazebo_plugin`/config/pepper_sensors.rviz
 ```
 
+
+## Docker
+We provide a docker image which is plattform independent and containerized, meaning it can't interfere with any local ROS installations or other incompatible packages you might have. You have two options to obtain the image:
++ Build it locally, from the provided dockerfile: `sudo docker build -t awesome-pepper-sim .` 
++ Pull it from dockerhub: `sudo docker pull frietz58/pepper-virtual:with-gazebo-files`
+
+Pulling it from dockerhub comes with the advantage of having the commited gazebo files, which otherwise have to be loaded when gazebo is started in the container. This happens automatically but takes about 30 seconds. Note that docker, per default, does not have permissions to spawn GUIs on the host system from within the container. There are a few options to address this (more about this described in [this fork](https://github.com/frietz58/pepper_virtual)), but we recommend installing the docker extension "rocker" to take care of this. Then, launch the container, depending on which option you chose earlier:
++ If build locally: `sudo rocker --nvidia --x11 awesome-pepper-sim`
++ If pulled from dockerhub: `sudo rocker --nvidia --x11 frietz58/pepper-virtual:with-gazebo-files`
+
+Then, just as above but in the container, do:
+```
+# Launch your preferred simulation here
+roslaunch pepper_gazebo_plugin pepper_gazebo_plugin_in_office_CPU.launch
+```
+In order to start a new shell in the container and, for example open RVIZ, run:
+```
+# First, find container ID with: sudo docker ps, then
+sudo docker exec -it <CONTAINER-ID> bash
+# Launch RVIZ in the second shell in the container:
+rosrun rviz rviz -d `rospack find pepper_gazebo_plugin`/config/pepper_sensors.rviz
+```
 ![screenshot of Pepper in Gazebo](gazebo_screenshot.png)
 
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ rosrun rviz rviz -d `rospack find pepper_gazebo_plugin`/config/pepper_sensors.rv
 
 ## Docker
 We provide a docker image which is plattform independent and containerized, meaning it can't interfere with any local ROS installations or other incompatible packages you might have. You have two options to obtain the image:
-+ Build it locally, from the provided dockerfile: `sudo docker build -t awesome-pepper-sim .` 
-+ Pull it from dockerhub: `sudo docker pull frietz58/pepper-virtual:with-gazebo-files`
++ Build it locally, from the provided dockerfile: `docker build -t awesome-pepper-sim .` 
++ Pull it from dockerhub: `docker pull frietz58/pepper-virtual:with-gazebo-files`
 
 Pulling it from dockerhub comes with the advantage of having the commited gazebo files, which otherwise have to be loaded when gazebo is started in the container. This happens automatically but takes about 30 seconds. Note that docker, per default, does not have permissions to spawn GUIs on the host system from within the container. There are a few options to address this (more about this described in [this fork](https://github.com/frietz58/pepper_virtual)), but we recommend installing the docker extension "rocker" to take care of this. Then, launch the container, depending on which option you chose earlier:
-+ If build locally: `sudo rocker --nvidia --x11 awesome-pepper-sim`
-+ If pulled from dockerhub: `sudo rocker --nvidia --x11 frietz58/pepper-virtual:with-gazebo-files`
++ If build locally: `rocker --nvidia --x11 awesome-pepper-sim`
++ If pulled from dockerhub: `rocker --nvidia --x11 frietz58/pepper-virtual:with-gazebo-files`
 
 Then, just as above but in the container, do:
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ roslaunch pepper_gazebo_plugin pepper_gazebo_plugin_in_office_CPU.launch
 In order to start a new shell in the container and, for example open RVIZ, run:
 ```
 # First, find container ID with: sudo docker ps, then
-sudo docker exec -it <CONTAINER-ID> bash
+docker exec -it <CONTAINER-ID> bash
 # Launch RVIZ in the second shell in the container:
 rosrun rviz rviz -d `rospack find pepper_gazebo_plugin`/config/pepper_sensors.rviz
 ```


### PR DESCRIPTION
Add dockerfile which can be built locally, as described in the new section in the readme. The new section in the readme also described how to pull the built image from dockerhub. The container state hosted in the dockerhub repo contains the gazebo files, so that they don't have to be download everytime the container is started (as hinted at [in the issue](https://github.com/awesomebytes/pepper_virtual/issues/7#issue-819430947)) 